### PR TITLE
chore: enable firewalld for all labs

### DIFF
--- a/proxy-and-peering-lab/scripts/install.sh
+++ b/proxy-and-peering-lab/scripts/install.sh
@@ -5,3 +5,9 @@ sudo yum install -q -y \
     vim \
     telnet \
     wget
+
+# Enable firewall for machines in this lab
+systemctl list-units --type=service --state=active | grep firewalld.service > /dev/null
+if [ $? -ne 0 ]; then
+    systemctl enable firewalld.service --now 2>&1
+fi

--- a/storage-lab/scripts/install.sh
+++ b/storage-lab/scripts/install.sh
@@ -5,3 +5,9 @@ sudo yum install -q -y \
     vim \
     telnet \
     wget
+
+# Enable firewall for machines in this lab
+systemctl list-units --type=service --state=active | grep firewalld.service > /dev/null
+if [ $? -ne 0 ]; then
+    systemctl enable firewalld.service --now 2>&1
+fi


### PR DESCRIPTION
All machines in labs must have Firewalld service enalbed. This forces us to
configure to practice configuring firewalls on every lab