### PR TITLE
fix: move VDI in ignore directory

### DIFF
--- a/storage-samba-lab/Vagrantfile
+++ b/storage-samba-lab/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure("2") do |config|
   # Workaround to avoid virtualbox captures microphone all the time
   config.vm.provider "virtualbox" do |vb|
     vb.customize ["modifyvm", :id, "--audio", "none"]
-    vb.memory = "1024"
+    vb.memory = "512"
   end
 
   # Server machine to host samba share
@@ -40,14 +40,14 @@ Vagrant.configure("2") do |config|
     client1.vm.provision "file", source: "~/.ssh/vagrant_rsa", destination: "~/.ssh/id_rsa"
 
     client1.vm.provider "virtualbox" do |vb|
-      unless File.exist?("./disk2.vdi")
+      unless File.exist?(".vagrant/disk2.vdi")
         vb.customize ["storagectl", :id, "--name", "SCSI", "--add", "scsi"]
       end
-      unless File.exist?("./disk2.vdi")
-        vb.customize ["createhd", "--filename", "./disk2.vdi", "--variant", "Fixed", "--size", 5 * 1024]
+      unless File.exist?(".vagrant/disk2.vdi")
+        vb.customize ["createhd", "--filename", ".vagrant/disk2.vdi", "--variant", "Fixed", "--size", 5 * 1024]
       end
-      unless File.exist?("./disk3.vdi")
-        vb.customize ["createhd", "--filename", "./disk3.vdi", "--variant", "Fixed", "--size", 10 * 1024]
+      unless File.exist?(".vagrant/disk3.vdi")
+        vb.customize ["createhd", "--filename", ".vagrant/disk3.vdi", "--variant", "Fixed", "--size", 10 * 1024]
       end
 
       vb.customize ["storageattach", :id,
@@ -55,14 +55,14 @@ Vagrant.configure("2") do |config|
                     "--port", 1,
                     "--device", 0,
                     "--type", "hdd",
-                    "--medium", "./disk2.vdi"]
+                    "--medium", ".vagrant/disk2.vdi"]
 
       vb.customize ["storageattach", :id,
                     "--storagectl", "SCSI",
                     "--port", 2,
                     "--device", 0,
                     "--type", "hdd",
-                    "--medium", "./disk3.vdi"]
+                    "--medium", ".vagrant/disk3.vdi"]
     end
   end
 


### PR DESCRIPTION
Moving generated VDI files into `.vagrant` directory so they are effectively ignored when provisioning vms.